### PR TITLE
added coredata(dailyPL) for tseries arg in tsboot() as opposed to just dailyPL

### DIFF
--- a/R/mcsim.R
+++ b/R/mcsim.R
@@ -149,7 +149,7 @@ mcsim <- function(  Portfolio
       sim <- 'fixed'
       # tsboot will use a fixed block length l
     }
-    tsb <- tsboot(dailyPL, function(x) { -max(cummax(cumsum(x))-cumsum(x)) }, n, l, sim = sim, ...)
+    tsb <- tsboot(coredata(dailyPL), function(x) { -max(cummax(cumsum(x))-cumsum(x)) }, n, l, sim = sim, ...)
     inds <- t(boot.array(tsb))
     #k <- NULL
     tsbootARR <- NULL


### PR DESCRIPTION
Added coredata(dailyPL) to the tsboot() function to replace dailyPL which is
an xts object and resulted in inaccurate cash max drawdowns.

This ensures accurate cash max drawdown calculations for the statistic arg
in tsboot, which yields a more accurate hist.mcsim histogram.
