### PR TITLE
Added Duration column to perTradeStats output

### DIFF
--- a/R/perTradeStats.R
+++ b/R/perTradeStats.R
@@ -157,6 +157,7 @@ perTradeStats <- function(Portfolio, Symbol, includeOpenTrade=TRUE, tradeDef="fl
     }
     trades$Start <- index(posPL)[trades$Start]
     trades$End <- index(posPL)[trades$End]
+    trades$Duration <- trades$End - trades$Start
 
     return(as.data.frame(trades))
 } # end fn perTradeStats


### PR DESCRIPTION
Adding a DURATION column will help simulating trades in the blotter::mcsim
function whilst maintaining strategy-specific characteristics

DURATION is simply the difference between the Start and End POSIXct
objects and it return value is a difftime object which includes the units
of the return value. This detail will be key for simulation purposes.
