### PR TITLE
Remove symbol=symbol param from getPrice method

### DIFF
--- a/R/txnsim.R
+++ b/R/txnsim.R
@@ -236,7 +236,7 @@ txnsim <- function(Portfolio, n = 10, replacement = TRUE,
     if (!is.null(dargs$prefer)) prefer <- dargs$prefer else prefer <- NULL
 
     prices <- getPrice(get(symbol, pos = env),
-                       symbol = symbol, prefer = prefer)[, 1]
+                       prefer = prefer)[, 1]
 
     # the rep list has a start, duration, quantity in each row
     # we'll loop by row over that object to create an object for addTxns


### PR DESCRIPTION
For quantstrat and blotter demos this param is not required and
depending on how user stores prices this param may result in txnsim
breaking if symbol name is not in the column text string of the
mktdata object, which getPrice(..., symbol=symbol) requires if getPrice
method is going to work properly.
