### PR TITLE
Add perTradeStats feature to accept a vector of symbols in the Symbol argument

### DIFF
--- a/R/perTradeStats.R
+++ b/R/perTradeStats.R
@@ -497,10 +497,11 @@ perTradeStats <- function(  Portfolio
     }
     
     if(combn.method == 'rbind') {
-      # add a 'Ticker' column 
+      # add a 'Symbol' column 
       for (symbol in Symbol) {
-        Ticker <- rep(toupper(symbol), nrow(trades[[symbol]]))
-        trades[[symbol]] <- cbind(Ticker, trades[[symbol]])
+        symbolname <- rep(toupper(symbol), nrow(trades[[symbol]]))
+        trades[[symbol]] <- cbind(symbolname, trades[[symbol]])
+        colnames(trades[[symbol]])[1] <- 'Symbol'
       }
       
       trades <- do.call(rbind, trades)

--- a/R/perTradeStats.R
+++ b/R/perTradeStats.R
@@ -496,7 +496,13 @@ perTradeStats <- function(  Portfolio
       trades[[symbol]] <- perTradeStats(Portfolio, Symbol = symbol)
     }
     
-    if(combn.method == 'rbind') { 
+    if(combn.method == 'rbind') {
+      # add a 'Ticker' column 
+      for (symbol in Symbol) {
+        Ticker <- rep(toupper(symbol), nrow(trades[[symbol]]))
+        trades[[symbol]] <- cbind(Ticker, trades[[symbol]])
+      }
+      
       trades <- do.call(rbind, trades)
       trades <- trades[order(as.POSIXct(trades$Start)), ] # sort by trades starting date
     }

--- a/R/perTradeStats.R
+++ b/R/perTradeStats.R
@@ -499,7 +499,7 @@ perTradeStats <- function(  Portfolio
     if(combn.method == 'rbind') {
       # add a 'Symbol' column 
       for (symbol in Symbol) {
-        symbolname <- rep(toupper(symbol), nrow(trades[[symbol]]))
+        symbolname <- rep(symbol, nrow(trades[[symbol]]))
         trades[[symbol]] <- cbind(symbolname, trades[[symbol]])
         colnames(trades[[symbol]])[1] <- 'Symbol'
       }

--- a/R/perTradeStats.R
+++ b/R/perTradeStats.R
@@ -74,6 +74,7 @@
 #' @param tradeDef string, one of 'flat.to.flat', 'flat.to.reduced', 'increased.to.reduced' or 'acfifo'. See Details.
 #' @param \dots any other passthrough parameters
 #' @param includeFlatPeriods boolean, default FALSE, whether to include flat periods in output, mostly useful for Monte Carlo simulation as in \code{\link{txnsim}}
+#' @param combn.method string, either 'rbind' or 'list'. If missing, 'rbind' will be used
 #' @param envir the environment to retrieve the portfolio from, defaults to .blotter
 #' @param Dates optional xts-style ISO-8601 time range to run trade stats over, default NULL (will use all timestamps)
 #' @author Brian G. Peterson, Jasen Mackie, Jan Humme
@@ -102,6 +103,9 @@
 #'      \item{tick.MFE}{ Maximum Favorable Excursion (MFE) in ticks}
 #'      \item{duration}{ \code{difftime} describing the duration of the round turn, in seconds }
 #' }
+#' 
+#' If \code{Symbol} is a vector with more than a symbol, return is either a \code{data.frame} containing the above statistics for all the symbol specified (default) 
+#' or a \code{list} containing the above statistics for each symbol specified, depending on the \code{combn.method} chosen.
 #'
 #' @seealso \code{\link{chart.ME}} for a chart of MAE and MFE derived from this function,
 #' and \code{\link{tradeStats}} for a summary view of the performance, and
@@ -113,6 +117,7 @@ perTradeStats <- function(  Portfolio
                           , tradeDef="flat.to.flat"
                           , ...
                           , includeFlatPeriods=FALSE
+                          , combn.method=c('rbind','list')
                           , envir=.blotter
                           , Dates=NULL
                           )
@@ -120,7 +125,12 @@ perTradeStats <- function(  Portfolio
 
   portf <- .getPortfolio(Portfolio, envir = envir)
   if(missing(Symbol)) Symbol <- ls(portf$symbols)[[1]]
-
+  if(missing(combn.method)) combn.method <- 'rbind'
+  
+  # inizialize main object
+  trades <- list()
+  
+  if(length(Symbol) == 1) {
   posPL <- portf$symbols[[Symbol]]$posPL
 
   if(!is.null(Dates)){
@@ -133,7 +143,6 @@ perTradeStats <- function(  Portfolio
   tradeDef <- match.arg(tradeDef, c("flat.to.flat","flat.to.reduced","increased.to.reduced","acfifo"))
   if(tradeDef=='acfifo') tradeDef<-'increased.to.reduced'
 
-  trades <- list()
   switch(tradeDef,
          flat.to.flat = {
            # identify start and end for each trade, where end means flat position
@@ -481,6 +490,17 @@ perTradeStats <- function(  Portfolio
   #add periodicity
   attr(trades, 'trade.periodicity') <- periodicity(posPL)
   
+  } else { # length(Symbol)>1, obtain stats for all the symbols specified
+    
+    for (symbol in Symbol) {
+      trades[[symbol]] <- perTradeStats(Portfolio, Symbol = symbol)
+    }
+    
+    if(combn.method == 'rbind') { 
+      trades <- do.call(rbind, trades)
+      trades <- trades[order(as.POSIXct(trades$Start)), ] # sort by trades starting date
+    }
+  }  
   return(trades)
 } # end fn perTradeStats
 

--- a/man/perTradeStats.Rd
+++ b/man/perTradeStats.Rd
@@ -6,7 +6,7 @@
 \usage{
 perTradeStats(Portfolio, Symbol, includeOpenTrade = TRUE,
   tradeDef = "flat.to.flat", ..., includeFlatPeriods = FALSE,
-  envir = .blotter, Dates = NULL)
+  combn.method = c("rbind", "list"), envir = .blotter, Dates = NULL)
 }
 \arguments{
 \item{Portfolio}{string identifying the portfolio}
@@ -20,6 +20,8 @@ perTradeStats(Portfolio, Symbol, includeOpenTrade = TRUE,
 \item{\dots}{any other passthrough parameters}
 
 \item{includeFlatPeriods}{boolean, default FALSE, whether to include flat periods in output, mostly useful for Monte Carlo simulation as in \code{\link{txnsim}}}
+
+\item{combn.method}{string, either 'rbind' or 'list'. If missing, 'rbind' will be used}
 
 \item{envir}{the environment to retrieve the portfolio from, defaults to .blotter}
 
@@ -49,6 +51,9 @@ A \code{data.frame} containing:
      \item{tick.MFE}{ Maximum Favorable Excursion (MFE) in ticks}
      \item{duration}{ \code{difftime} describing the duration of the round turn, in seconds }
 }
+
+If \code{Symbol} is a vector with more than a symbol, return is either a \code{data.frame} containing the above statistics for all the symbol specified (default) 
+or a \code{list} containing the above statistics for each symbol specified, depending on the \code{combn.method} chosen.
 }
 \description{
 One 'trade' is defined as a series of transactions which make up a 'round turn'.


### PR DESCRIPTION
Address issue [#42](https://github.com/braverock/blotter/issues/42) and [#43](https://github.com/braverock/blotter/issues/43).

This pull request extends `perTradeStats` to accept a vector of symbols included in the portfolio object. In this case, the return type can be decided using the newly introduced parameter `combn.method` suggested by @braverock. 

_Please note_: the present pull request is intended to replace pull request [#79](https://github.com/braverock/blotter/pull/79).